### PR TITLE
Enabled multiple importers support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default function() {
     }
 
     aliases.set(base, { file: url });
-    done({ file: url });
+    return null;
 
   };
 


### PR DESCRIPTION
 This PR fixes [this issue](https://github.com/lucasmotta/sass-module-importer/issues/16), and now you can use this importer with other importers too, like this:

``` js
importer: [globImporter(), moduleImporter()]
```

Based on the [documentation of node sass](https://github.com/sass/node-sass#importer--v200---experimental)

> importer can be an array of functions, which will be called by LibSass in the order of their occurrence in array. If an importer does not want to handle a particular path, it should return null.

Note: I had to update to babel 6 to run the tests, on [this branch](https://github.com/marcofugaro/sass-glob-importer/tree/update-dependencies) the changes I made
